### PR TITLE
clean up formatting: normalize indentation and compact macros

### DIFF
--- a/config/hillside46.keymap
+++ b/config/hillside46.keymap
@@ -33,14 +33,14 @@
 #include "combos.dtsi"
 
 &mt {
-	flavor = "balanced";
+    flavor = "balanced";
 };
 &sk {
-        quick-release;
+    quick-release;
 };
 &caps_word {
-        // Allow caps word to continue even when minus, delete, left or underscore are pressed.
-        continue-list = <UNDERSCORE MINUS BACKSPACE DELETE LEFT>;
+    // Allow caps word to continue even when minus, delete, left or underscore are pressed.
+    continue-list = <UNDERSCORE MINUS BACKSPACE DELETE LEFT>;
 };
 
 / {
@@ -51,7 +51,7 @@
                 then-layer = <4>;
             };
         };
-	behaviors {
+        behaviors {
                 td0: td_ply_nxt {
                         compatible = "zmk,behavior-tap-dance";
                         label = "TD_PLY_NXT";
@@ -107,43 +107,27 @@
                         tapping-term-ms = <200>;
                         bindings = <&mo>, <&ss_cw>;
                 };           
-	};
+        };
         macros {
                 win_left: win_left_macro {
                         compatible = "zmk,behavior-macro";
                         #binding-cells = <0>;
-                        bindings
-                                = <&macro_press &kp LGUI>
-                                , <&macro_tap &kp LEFT>
-                                , <&macro_release &kp LGUI>
-                                ;
+                        bindings = <&macro_press &kp LGUI>, <&macro_tap &kp LEFT>, <&macro_release &kp LGUI>;
                 };
                 win_right: win_right_macro {
                         compatible = "zmk,behavior-macro";
                         #binding-cells = <0>;
-                        bindings
-                                = <&macro_press &kp LGUI>
-                                , <&macro_tap &kp RIGHT>
-                                , <&macro_release &kp LGUI>
-                                ;
+                        bindings = <&macro_press &kp LGUI>, <&macro_tap &kp RIGHT>, <&macro_release &kp LGUI>;
                 };
                 win_up: win_up_macro {
                         compatible = "zmk,behavior-macro";
                         #binding-cells = <0>;
-                        bindings
-                                = <&macro_press &kp LGUI>
-                                , <&macro_tap &kp UP>
-                                , <&macro_release &kp LGUI>
-                                ;
+                        bindings = <&macro_press &kp LGUI>, <&macro_tap &kp UP>, <&macro_release &kp LGUI>;
                 };
                 win_down: win_down_macro {
                         compatible = "zmk,behavior-macro";
                         #binding-cells = <0>;
-                        bindings
-                                = <&macro_press &kp LGUI>
-                                , <&macro_tap &kp DOWN>
-                                , <&macro_release &kp LGUI>
-                                ;
+                        bindings = <&macro_press &kp LGUI>, <&macro_tap &kp DOWN>, <&macro_release &kp LGUI>;
                 };
         };
 
@@ -162,11 +146,11 @@
                         bindings = <
 &kp GRAVE      &kp Q &kp W &kp E &kp R &kp T &kp Y                                                    &kp U   &kp I  &kp O   &kp P    &mt RBKT LBKT
 &kp LA(LC(TAB)) &hrm LGUI A &hrm LALT S &hrm LSHIFT D &hrm LCTRL F  &kp G                             &kp H  &hrm RCTRL J &hrm RSHIFT K &hrm LALT L &hrm RGUI SEMI &kp SQT
-&kp MINUS 	&kp Z &kp X &kp C &kp V &kp B   &kp ESC                                   &kp INSERT  &kp N  &kp M  &kp COMMA    &kp DOT &kp FSLH &kp BSLH
+&kp MINUS      &kp Z &kp X &kp C &kp V &kp B   &kp ESC                                   &kp INSERT  &kp N  &kp M  &kp COMMA    &kp DOT &kp FSLH &kp BSLH
                                 &lt HK BSPC &lt FZ TAB &lt NUM SPACE &lt HK RETURN     &lt HK RETURN &cw_ht NAV 0 &lt FZ BSPC &mt LALT DEL
                         >;
                 };
-		
+
                 numbers_layer {
 /* NUM - left: numpad 789/456/123 | right: symbols ^&*() and F6-F11 | -/ and +* are tap-dance
  * -------------------------------------------------------------------------------------------------------------------------------------
@@ -177,9 +161,9 @@
  */
                         bindings = <
 XXX             &kp EQUAL  &kp N7 &kp N8 &kp N9 &td1 &kp F6                 &kp F7   &kp F8   &kp F9   &kp F10  &kp F11
-&kp ENTER    	&kp COLON  &kp N4 &kp N5 &kp N6 &td2                        &kp CARET   &hrm RCTRL AMPS &hrm RSHIFT STAR &hrm LALT LPAR &hrm RGUI RPAR &kp MINUS
+&kp ENTER        &kp COLON  &kp N4 &kp N5 &kp N6 &td2                        &kp CARET   &hrm RCTRL AMPS &hrm RSHIFT STAR &hrm LALT LPAR &hrm RGUI RPAR &kp MINUS
 &kp C_AL_CALC   &kp KP_DOT &kp N1 &kp N2 &kp N3 &kp N0 XXX              ___ ___    &kp KP_N7   &kp KP_N8   &kp KP_N9   &kp KP_N0   XXX
-                                                ___ ___ ___ ___ 	___ ___ ___ &kp F12 
+                                                ___ ___ ___ ___     ___ ___ ___ &kp F12 
                         >;
                 };
 
@@ -192,8 +176,8 @@ XXX             &kp EQUAL  &kp N7 &kp N8 &kp N9 &td1 &kp F6                 &kp 
  *                                 |       |       |       |       |---|       |       |       |       |
  */
                         bindings = <
-XXX	        &kp F1      &kp F2 &kp F3   &kp F4      &kp F5                                   &kp HOME      &kp PG_DN        &kp PG_UP       &kp END   	XXX             &kp C_VOL_UP
-&kp KP_EQUAL   &hrm LGUI EXCL  &hrm LALT AT &hrm LSHIFT HASH &hrm LCTRL DLLR  &kp PRCNT          &kp LEFT      &kp DOWN 	&kp UP          &kp RIGHT       &kp RALT        &td0
+XXX            &kp F1      &kp F2 &kp F3   &kp F4      &kp F5                                   &kp HOME      &kp PG_DN        &kp PG_UP       &kp END       XXX             &kp C_VOL_UP
+&kp KP_EQUAL   &hrm LGUI EXCL  &hrm LALT AT &hrm LSHIFT HASH &hrm LCTRL DLLR  &kp PRCNT          &kp LEFT      &kp DOWN     &kp UP          &kp RIGHT       &kp RALT        &td0
 XXX         &kp KP_N1   &kp KP_N2 &kp KP_N3 &kp KP_N4 &kp KP_N5  ___                        ___  &kp LC(LEFT)  &kp LC(PG_DN)    &kp LC(PG_UP)   &kp LC(RIGHT)   XXX             &kp C_VOL_DN
                                                         ___ ___ ___ ___                 ___ ___ ___ ___
                         >;
@@ -214,7 +198,7 @@ XXX     XXX &kp LC(F1) &kp LC(F2) &kp LC(F3) &kp LG(N0) ___                     
                                                 ___ ___ ___ ___              ___ ___ ___ ___
                         >;
                 };
-		
+
                 adj_layer {
 /* ADJUST - active when NUM+NAV held simultaneously
  * -------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Replaced all tab characters with spaces throughout `config/hillside46.keymap` for consistent indentation
- Normalized `&mt`, `&sk`, and `&caps_word` top-level node bodies to 4-space indentation (was a mix of tabs and 8 spaces)
- Fixed `behaviors { }` block header/footer which used tabs while everything inside used spaces
- Compacted the four `win_*` macros from verbose multi-line `bindings` format to single-line — 36 lines → 20 lines, no semantic change
- Cleaned up stray tab characters on blank lines and inside binding rows

## No functional changes

All keymap behavior is identical. This is purely cosmetic/formatting cleanup.